### PR TITLE
Feat: Configure React UI route and build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,15 @@ RUN apt-get install -y nodejs
 COPY package.json ./
 RUN npm install
 
+# Copy frontend package files and install frontend dependencies
+COPY frontend/package.json frontend/package-lock.json* ./frontend/
+RUN npm install --prefix frontend
+
 # Copy the current directory contents into the container at /app
 COPY . .
 
 # Build CSS and React App
+# This will use the dependencies installed in ./frontend/node_modules
 RUN npm run build
 
 # Install any needed packages specified in pyproject.toml

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Frontend assets for Meal Planner App",
   "scripts": {
     "build:css": "tailwindcss -i ./meal_planner_app/static/css/src/input.css -o ./meal_planner_app/static/css/dist/output.css --minify",
-    "build:react": "npm --prefix frontend run build",
+    "build:react": "mkdir -p ./meal_planner_app/static/react_app && npm --prefix frontend run build",
     "build": "npm run build:css && npm run build:react"
   },
   "devDependencies": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ dev = [
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["meal_planner_app"]


### PR DESCRIPTION
- Added Flask route in `main.py` to serve the React application from `/ui/`.
  - Expects React build output in `meal_planner_app/static/react_app/`.
- Configured `frontend/vite.config.js` to:
  - Output build files to `../meal_planner_app/static/react_app`.
  - Set `base: '/static/react_app/'` for correct asset pathing.
- Modified `build:react` script in root `package.json` to ensure the target directory `meal_planner_app/static/react_app` is created before Vite build.

Note: Further debugging may be required due to an observed ECONNREFUSED error, potentially indicating an issue with Flask app startup or accessibility within the container.