### PR TITLE
docs: Add migration plan for Jinja2 to Headless API

### DIFF
--- a/.ai/feature_summary.md
+++ b/.ai/feature_summary.md
@@ -1,0 +1,55 @@
+# Feature Summary
+
+This document outlines the major features of the Meal Planning Tool, based on the information provided in the `README.md` file and subsequent user feedback.
+
+## High-Level Summary
+
+*   **Automatic Recipe Discovery:** The application can automatically find and import recipes from the web using two different modes: a search-based discovery and a direct URL extraction.
+*   **Ingredient Management:** The application provides a centralized place to manage ingredients, supporting flexible units of measure (e.g., quantity, weight, package).
+*   **Recipe Management:** The application allows users to create, read, update, and delete meal recipes with detailed metadata.
+*   **Meal Plan Management:** Users can create, read, update, and delete weekly or daily meal plans.
+*   **Shopping List Generation:** The system can automatically generate a shopping list from a meal plan, which can then be manually adjusted.
+*   **Modern UI (In-Progress):** A new user interface is being developed using React to provide a more modern user experience for some features.
+*   **API for Recipes:** A JSON API is available to fetch recipe data, allowing for decoupling the frontend from the backend.
+
+## Detailed Feature Descriptions
+
+### Automatic Recipe Discovery
+This is a powerful feature for populating the recipe database with minimal manual entry. It operates in two modes:
+1.  **Search-Based Discovery:** Users can provide a list of ingredients or a type of dish (e.g., "vegan pasta"). The system then searches the web for matching recipes and presents a list of potential candidates for the user to import.
+2.  **URL-Based Extraction:** If a user has already found a recipe they like, they can provide the URL directly. The system will then crawl that specific page, extract all relevant information (ingredients, instructions, etc.) using an intelligent, possibly AI-supported, process, and add it to the recipe database.
+
+### Ingredient Management
+The application allows for the management of a master list of ingredients. A key aspect of this feature is the support for **flexible measurement units**. This means an ingredient in a recipe is not tied to a single unit type. It can be defined by:
+*   **Quantity:** e.g., "2 apples"
+*   **Weight:** e.g., "250g of flour"
+*   **Volume:** e.g., "1 cup of milk"
+*   **Packaging:** e.g., "1 can of tomatoes"
+This flexibility is crucial for accurately importing recipes and for generating useful shopping lists.
+
+### Recipe Management
+The core of the application is the ability to manage a collection of recipes. In addition to standard CRUD operations, recipes can store rich metadata:
+*   A list of ingredients with their flexible quantities and units.
+*   The source of the recipe (e.g., a URL).
+*   The preparation time as declared in the recipe source.
+*   The actual time it takes to prepare the dish, based on user experience.
+*   The shelf life of the final dish (i.e., for how long it is edible).
+
+This feature is primarily implemented using server-rendered Jinja2 templates.
+
+### Meal Plan Management
+Users can organize recipes into meal plans. This feature allows for the creation of daily or weekly meal schedules.
+
+### Shopping List Generation
+A key utility of the application is its ability to simplify grocery shopping. After a user creates a meal plan, the application can process all the recipes in that plan and generate a consolidated shopping list. A crucial part of this feature is the ability for the user to **manually edit the list after generation**. The system must also be ableto intelligently handle the consolidation of flexible units where possible.
+
+### Modern User Interface (React Frontend)
+The project includes a newer, more modern frontend built with React, accessible at the `/ui/` endpoint.
+
+### Recipe API
+The application exposes a RESTful API endpoint at `/api/recipes` to serve recipe data in JSON format.
+
+### Future Goals / Desired Features
+The documentation also outlines several long-term goals for the application:
+*   **Advanced Recipe Search:** A powerful search function to find recipes stored locally based on specific criteria.
+*   **PDF Export:** The ability to export meal plans or shopping lists to a PDF file for easy printing or sharing.

--- a/.ai/migration_plan.md
+++ b/.ai/migration_plan.md
@@ -1,0 +1,52 @@
+# Migration Plan: From Jinja2 to a Headless API
+
+## 1. Introduction
+
+This document outlines a strategic plan for migrating the Meal Planner application from its current hybrid architecture (part server-rendered Jinja2, part React) to a modern, fully decoupled architecture consisting of a headless Flask API and a comprehensive React single-page application (SPA).
+
+**Goal:** To improve scalability, developer experience, and user experience by completing the transition to a modern web architecture.
+
+## 2. Current State vs. Target State
+
+*   **Current State:** A Flask application that serves both a JSON API (`/api/*`) and server-rendered HTML pages via Jinja2 templates. A separate React application exists at `/ui/` for some features.
+*   **Target State:** A "headless" Flask application that functions exclusively as a JSON API server. A single, comprehensive React application that handles all user interface rendering and interacts with the Flask backend via the API.
+
+## 3. Phased Migration Strategy
+
+A phased approach is recommended to minimize risk and ensure a smooth transition.
+
+### Phase 1: Solidify the API Foundation
+
+The API is the backbone of the target architecture. Before migrating more UI features, the API must be robust and complete.
+
+*   **Action 1.1: Full API Coverage.** Audit the existing Jinja2 pages. Identify all data and functionality they provide and ensure there is a corresponding API endpoint for each. For example, if meal plans are only managed via Jinja2, create full CRUD API endpoints for them (`/api/meal-plans`).
+*   **Action 1.2: API Authentication.** Implement a secure authentication/authorization mechanism for the API (e.g., using tokens like JWT). This is critical once the UI is fully decoupled.
+*   **Action 1.3: API Documentation.** Document all API endpoints clearly using a standard like OpenAPI (Swagger). This will be essential for frontend development.
+
+### Phase 2: Achieve Feature Parity in React
+
+The goal of this phase is to rebuild all features currently handled by Jinja2 within the React application.
+
+*   **Action 2.1: Prioritize and Migrate.** Create a list of all pages/features currently rendered by Jinja2 (e.g., Recipe CRUD, Meal Plan CRUD, Shopping List Generation). Migrate them one by one into the React application. A good pilot candidate would be the "Meal Plan Management" feature.
+*   **Action 2.2: Consistent UI/UX.** Ensure the new React components match or improve upon the user experience of the old pages.
+*   **Action 2.3: Comprehensive Testing.** For each migrated feature, write end-to-end tests to verify that the new React-based workflow is functionally identical to the old Jinja2-based one.
+
+### Phase 3: Decommission Legacy Components
+
+Once all features have been successfully migrated to and verified in the React application, the old components can be removed.
+
+*   **Action 3.1: Remove Jinja2 Routes.** Delete the Flask routes that were responsible for rendering the now-obsolete HTML pages. For example, the route for `/recipes/add` would be removed, as this is now handled by the React frontend.
+*   **Action 3.2: Remove Template Files.** Delete the associated Jinja2 template files (`.html`) from the `templates` directory.
+*   **Action 3.3: Final Cleanup.** Remove any parts of the Flask application that were solely in support of the Jinja2 rendering (e.g., specific form handling libraries if they are no longer needed).
+
+## 4. Key Considerations
+
+*   **API Design:** A well-designed and consistent API is the most critical success factor.
+*   **Testing:** Rigorous E2E testing is essential to prevent regressions during the migration.
+*   **Deployment:** The frontend and backend can be deployed independently in the target state, but the process needs to be planned. The React app can be served as static files from a CDN or from the Flask server itself.
+
+## 5. Recommended First Steps
+
+1.  Create API endpoints for full CRUD functionality on **Meal Plans**.
+2.  Implement the Meal Plan management interface in React, using the new API endpoints.
+3.  Once verified, remove the old Jinja2-based Meal Plan pages.

--- a/.ai/requirements.md
+++ b/.ai/requirements.md
@@ -1,0 +1,88 @@
+# System Requirements
+
+This document outlines the functional and non-functional requirements for the Meal Planning Tool. These are derived from the feature summary and an analysis of the project's goals.
+
+## 1. Functional Requirements
+
+Functional requirements define the specific behaviors and functions of the system.
+
+### 1.1 Automatic Recipe Discovery
+
+#### 1.1.1 Search-Based Discovery
+*   **FR-1.1.1.1:** The system shall provide an interface for the user to input a search query, such as a list of ingredients or a type of dish.
+*   **FR-1.1.1.2:** The system shall use the user's query to search the web for relevant recipe pages.
+*   **FR-1.1.1.3:** The system shall display a list of search results (e.g., titles and links) to the user.
+*   **FR-1.1.1.4:** The system shall allow the user to select a search result to initiate the extraction process described in the next section.
+
+#### 1.1.2 URL-Based Extraction
+*   **FR-1.1.2.1:** The system shall provide an interface for the user to submit a single URL pointing to a recipe page.
+*   **FR-1.1.2.2:** The system shall crawl the provided webpage to retrieve its content.
+*   **FR-1.1.2.3:** The system shall use an intelligent/AI-driven process to parse the webpage content and extract key recipe information (e.g., name, instructions, ingredients, quantities, units).
+*   **FR-1.1.2.4:** The system shall present the extracted information to the user for review and confirmation, potentially by pre-filling the standard "Add Recipe" form.
+
+### 1.2 Recipe Management
+
+*   **FR-1.2.1:** The system shall allow a user to create a new recipe, providing fields for: a recipe name, preparation instructions, the recipe's source URL, the declared preparation time, the actual preparation time, and the dish's shelf life.
+*   **FR-1.2.2:** The system shall allow a user to associate a list of ingredients with a recipe, using the flexible unit system defined in Ingredient Management.
+*   **FR-1.2.3:** The system shall display a list of all saved recipes.
+*   **FR-1.2.4:** The system shall allow a user to view the full details of a single recipe, including all its metadata and ingredients.
+*   **FR-1.2.5:** The system shall allow a user to edit the details of an existing recipe.
+*   **FR-1.2.6:** The system shall allow a user to delete a recipe from the system.
+*   **FR-1.2.7:** The system shall provide an API endpoint (`/api/recipes`) that returns a list of all recipes in JSON format.
+
+### 1.3 Ingredient Management
+
+*   **FR-1.3.1:** The system shall allow a user to create a new ingredient with a unique name.
+*   **FR-1.3.2:** The system shall allow a user to view a list of all available ingredients.
+*   **FR-1.3.3:** The system shall allow a user to edit or delete an existing ingredient.
+*   **FR-1.3.4:** The system shall support a flexible data model for ingredient measurements, capturing a numeric amount and a unit string which can represent quantity, weight (e.g., "g", "kg"), volume (e.g., "ml", "cup"), or packaging (e.g., "can", "package").
+
+### 1.4 Meal Plan Management
+
+*   **FR-1.4.1:** The system shall allow a user to create a new meal plan, specifying a name or date range for the plan.
+*   **FR-1.4.2:** The system shall allow a user to add recipes from the recipe collection to a meal plan.
+*   **FR-1.4.3:** The system shall display the details of a meal plan.
+*   **FR-1.4.4:** The system shall allow a user to edit or delete a meal plan.
+
+### 1.5 Shopping List Generation
+
+*   **FR-1.5.1:** The system shall automatically generate a shopping list based on a selected meal plan.
+*   **FR-1.5.2:** The system shall consolidate ingredients from multiple recipes. Consolidation should only occur for identical ingredients with compatible units (e.g., 'g' with 'kg', 'cup' with 'cup'). The system should not attempt to consolidate incompatible units (e.g., 'cups' with 'grams' without a conversion table, or 'apples' with 'grams').
+*   **FR-1.5.3:** The system shall display the generated shopping list to the user.
+*   **FR-1.5.4:** The system shall allow the user to manually add, edit, or remove items from the generated shopping list.
+
+### 1.6 User Interface
+
+*   **FR-1.6.1:** The system shall provide a web-based user interface accessible through a browser.
+*   **FR-1.6.2:** The traditional interface (Jinja2) shall provide access to all defined features.
+*   **FR-1.6.3:** The modern interface (React @ `/ui/`) shall provide, at a minimum, the ability to display recipes.
+
+### 1.7 Future/Desired Features
+
+*   **FR-1.7.1:** The system should provide an advanced search functionality to filter locally stored recipes.
+*   **FR-1.7.2:** The system should allow exporting a shopping list or meal plan to a PDF document.
+
+## 2. Non-Functional Requirements
+
+Non-functional requirements define the quality attributes and constraints of the system.
+
+### 2.1 Performance
+*   **NFR-2.1.1:** Web pages should load in a user's browser in under 3 seconds on a standard broadband connection.
+*   **NFR-2.1.2:** Recipe search/extraction from a given URL should complete within 15 seconds.
+*   **NFR-2.1.3:** The `/api/recipes` endpoint should respond with data in under 500ms for up to 1000 recipes.
+
+### 2.2 Usability
+*   **NFR-2.2.1:** The user interface should be intuitive and require minimal training.
+*   **NFR-2.2.2:** The system should provide clear feedback to the user during the recipe extraction process (e.g., "Crawling page...", "Extracting ingredients...", "Success!").
+
+### 2.3 Reliability
+*   **NFR-2.3.1:** The application should be available and operational 99.9% of the time.
+*   **NFR-2.3.2:** The system should handle common user errors gracefully (e.g., invalid URL, non-recipe webpage).
+
+### 2.4 Maintainability
+*   **NFR-2.4.1:** The codebase should be well-documented.
+*   **NFR-2.4.2:** The project should follow a consistent coding style.
+*   **NFR-2.4.3:** The AI/extraction logic should be modular and separable from the core application logic to allow for independent updates and improvements.
+
+### 2.5 AI/Extraction Accuracy
+*   **NFR-2.5.1:** The AI extraction process shall correctly identify and extract ingredients and their quantities with at least 90% accuracy on a benchmark set of common recipe websites.

--- a/.ai/stack.md
+++ b/.ai/stack.md
@@ -1,0 +1,64 @@
+# Technology Stack
+
+This document provides an overview of the technologies, frameworks, and tools used in the Meal Planner application.
+
+## Backend Technologies
+
+*   **Language:** Python 3.9
+*   **Framework:** Flask
+    *   *Description:* A lightweight WSGI web application framework used to build the backend API and server-rendered pages.
+*   **PDF Generation:** fpdf2
+    *   *Description:* A Python library used for generating PDF documents, intended for the "Export to PDF" feature.
+
+## Frontend Technologies
+
+*   **Core Library:** React (v18.2.0)
+    *   *Description:* A JavaScript library for building modern, interactive user interfaces. Used for the new UI at the `/ui/` endpoint.
+*   **DOM Rendering:** React DOM (v18.2.0)
+    *   *Description:* The companion library to React that renders components in the web browser.
+*   **Templating (Legacy):** Jinja2
+    *   *Description:* A templating engine for Python, used by Flask to render the traditional server-side pages of the application.
+
+## Styling
+
+*   **CSS Framework:** Tailwind CSS (v3.0.0)
+    *   *Description:* A utility-first CSS framework used for styling both the Jinja2 templates and the React components.
+*   **CSS Processing:** PostCSS / Autoprefixer
+    *   *Description:* Tools used to process and add vendor prefixes to the CSS for better browser compatibility.
+
+## Build Tools & Package Management
+
+*   **Backend Package Manager:** pip
+    *   *Description:* The standard package manager for Python, used to install dependencies defined in `pyproject.toml`.
+*   **Frontend Build Tool:** Vite (v4.4.5)
+    *   *Description:* A modern frontend build tool that provides a fast development server (with Hot Module Replacement) and bundles the React application for production.
+*   **JavaScript Package Manager:** npm
+    *   *Description:* The Node Package Manager, used to manage all JavaScript dependencies for both the React application and the build tools.
+*   **Code Linting:**
+    *   **Pylint:** For Python code quality.
+    *   **ESLint:** For JavaScript and React code quality.
+
+## Development & Deployment Environment
+
+*   **Containerization:** Docker
+    *   *Description:* The application is configured to run inside a Docker container, ensuring a consistent and reproducible environment.
+*   **Base OS:** Debian (via `python:3.9-slim` image)
+    *   *Description:* The Docker container is built on top of a slim version of the Debian Linux distribution.
+*   **Runtime:** Node.js (v18.x)
+    *   *Description:* The JavaScript runtime required for installing dependencies and running all build tools (Vite, Tailwind CSS, etc.).
+*   **Web Server:** Flask Development Server
+    *   *Description:* The built-in development server provided by Flask is used to serve the application from within the container.
+
+## Technology Recommendations for New Features
+
+This section provides suggestions for libraries and tools that could be used to implement the new features outlined in the requirements document.
+
+### Automatic Recipe Discovery
+
+*   **Web Searching (for Search-Based Discovery):**
+    *   **Recommendation:** Use a dedicated search engine API like the **Google Custom Search JSON API**. This is more reliable and robust than attempting to scrape search engine result pages directly. There are Python client libraries available to simplify its use.
+*   **Web Crawling/Scraping (for URL-Based Extraction):**
+    *   **Recommendation:** A combination of **Requests** (for fetching page HTML) and **BeautifulSoup4** (for parsing the HTML). This stack is simple and effective for extracting data from single pages.
+    *   **Alternative:** For more complex scenarios involving asynchronous crawling or following links, **Scrapy** is a powerful framework to consider.
+*   **AI-Powered Data Extraction (NLP):**
+    *   **Recommendation:** Use a pre-trained Named Entity Recognition (NER) model from a library like **spaCy** or **Hugging Face Transformers**. These models can be fine-tuned to recognize entities like `INGREDIENT`, `QUANTITY`, `UNIT`, and `INSTRUCTION` from raw recipe text, which is more robust than using simple regular expressions.

--- a/.ai/test_plan.md
+++ b/.ai/test_plan.md
@@ -1,0 +1,98 @@
+# Detailed Test Plan
+
+## 1. Introduction
+
+This document outlines the test plan for the Meal Planner application. Its purpose is to provide a comprehensive strategy for verifying the functionality, reliability, and performance of the system. This plan is based on the features and requirements defined in `feature_summary.md` and `requirements.md`.
+
+## 2. Scope
+
+### 2.1 In Scope
+
+*   Testing of all defined features, including Automatic Recipe Discovery, Recipe/Ingredient Management, Meal Plan Management, and Shopping List Generation.
+*   Verification of both the traditional Jinja2-based UI and the modern React-based UI.
+*   Testing of the `/api/recipes` API endpoint.
+*   Validation of all non-functional requirements, including performance and AI accuracy.
+
+### 2.2 Out of Scope
+
+*   This document does not include the *implementation* of the tests, only the plan.
+*   Testing of third-party dependencies (e.g., the Flask framework itself) is not in scope.
+
+## 3. Test Strategy
+
+A multi-layered testing approach will be used:
+
+*   **Unit Tests:** To test individual functions and components in isolation. `pytest` for the backend and React Testing Library/Jest for the frontend are recommended.
+*   **Integration Tests:** To test the interaction between components, such as the interaction between the Flask routes and the database logic.
+*   **API Tests:** To directly test the `/api/recipes` endpoint for correctness, error handling, and performance. Tools like `Postman` or `pytest` with an HTTP client can be used.
+*   **End-to-End (E2E) Tests:** To simulate real user workflows in a browser. This is critical for testing both the Jinja2 and React UIs. Tools like `Playwright` or `Cypress` are recommended.
+*   **Manual Testing:** For exploratory testing and validating usability requirements that are difficult to automate.
+
+## 4. Test Cases
+
+### 4.1 Automatic Recipe Discovery
+
+#### 4.1.1 Search-Based Discovery
+| Test ID | Requirement(s) | Test Description | Test Steps | Expected Result | Test Type |
+|---|---|---|---|---|---|
+| **TC-ARD-S-001** | FR-1.1.1.1, FR-1.1.1.2 | Verify user can search for recipes by dish type. | 1. Navigate to "Discover Recipes".<br>2. Enter "chicken pasta" into the search field.<br>3. Submit the search. | The system displays a list of links to recipes related to "chicken pasta". | E2E |
+| **TC-ARD-S-002** | FR-1.1.1.3, FR-1.1.1.4 | Verify user can select a search result for extraction. | 1. Perform a search.<br>2. Click the "Import" or "Extract" button next to a valid search result. | The system proceeds to the URL-based extraction workflow for the selected link. | E2E |
+
+#### 4.1.2 URL-Based Extraction
+| Test ID | Requirement(s) | Test Description | Test Steps | Expected Result | Test Type |
+|---|---|---|---|---|---|
+| **TC-ARD-U-001** | FR-1.1.2.1, FR-1.1.2.2 | Verify user can submit a URL for extraction. | 1. Navigate to "Import from URL".<br>2. Enter a valid recipe URL.<br>3. Click "Extract". | The system shows a loading/progress indicator and begins the extraction process. | E2E |
+| **TC-ARD-U-002** | FR-1.1.2.3, FR-1.1.2.4 | Verify recipe data is extracted and presented for confirmation. | 1. Submit a valid URL for extraction. | The "Add Recipe" form is displayed, pre-filled with the extracted name, instructions, and ingredients for user review. | Integration |
+| **TC-ARD-U-003** | NFR-2.3.2 | Verify system handles a non-recipe URL gracefully. | 1. Submit a URL that is not a recipe (e.g., google.com). | The system displays a user-friendly error message, such as "Could not find a recipe at the provided URL." | E2E |
+
+### 4.2 Recipe Management
+
+| Test ID | Requirement(s) | Test Description | Test Steps | Expected Result | Test Type |
+|---|---|---|---|---|---|
+| **TC-REC-001** | FR-1.2.1, FR-1.2.2 | Verify user can create a recipe with all metadata. | 1. Navigate to "Add Recipe".<br>2. Fill in all fields, including times and shelf-life.<br>3. Submit. | The new recipe is created and visible in the recipe list. | E2E |
+| **TC-REC-002** | FR-1.2.3, FR-1.2.4 | Verify recipe list and detail pages display correctly. | 1. Navigate to the recipe list.<br>2. Click on a recipe. | All recipes are listed. The detail page shows all saved metadata correctly. | E2E |
+| **TC-REC-003** | FR-1.2.5 | Verify a user can edit an existing recipe. | 1. Navigate to a recipe's detail page.<br>2. Click "Edit" and change a field.<br>3. Submit. | The recipe's details are updated with the new information. | E2E |
+| **TC-REC-004** | FR-1.2.6 | Verify a user can delete a recipe. | 1. Navigate to a recipe's detail page.<br>2. Click "Delete" and confirm. | The recipe is removed from the recipe list. | E2E |
+| **TC-REC-005** | FR-1.2.7 | Verify the `/api/recipes` endpoint returns a list of recipes. | 1. Send a GET request to `/api/recipes`. | The API returns a `200 OK` status with a JSON array of recipe objects. | API |
+| **TC-REC-006** | FR-1.6.3 | Verify that recipes are displayed on the React UI. | 1. Navigate to the `/ui/` page. | The page loads and displays a list of recipes fetched from the API. | E2E |
+| **TC-REC-007** | FR-1.3.4 | Verify recipe can be created with flexible ingredient units. | 1. Create a recipe.<br>2. Add an ingredient with quantity "250" and unit "g".<br>3. Add another with "1" and "can".<br>4. Save. | The recipe saves and displays the ingredients with their correct flexible units. | E2E |
+
+### 4.3 Ingredient Management
+
+| Test ID | Requirement(s) | Test Description | Test Steps | Expected Result | Test Type |
+|---|---|---|---|---|---|
+| **TC-ING-001** | FR-1.3.1 | Verify a user can create a new ingredient. | 1. Navigate to "Manage Ingredients".<br>2. Click "Add Ingredient", enter a name, and save. | The new ingredient appears in the master list. | E2E |
+| **TC-ING-002** | FR-1.3.2 | Verify the ingredient list page displays all items. | 1. Navigate to "Manage Ingredients". | All created ingredients are displayed. | E2E |
+| **TC-ING-003** | FR-1.3.3 | Verify a user can edit or delete an ingredient. | 1. From the ingredient list, edit or delete an item. | The ingredient is updated or removed from the list. | E2E |
+
+### 4.4 Meal Plan Management
+
+| Test ID | Requirement(s) | Test Description | Test Steps | Expected Result | Test Type |
+|---|---|---|---|---|---|
+| **TC-MP-001** | FR-1.4.1, FR-1.4.2 | Verify a user can create a meal plan and add recipes. | 1. Navigate to "Create Meal Plan".<br>2. Name the plan, add recipes, and save. | The new meal plan is created and displayed, showing the selected recipes. | E2E |
+| **TC-MP-002** | FR-1.4.4 | Verify that a user can edit or delete a meal plan. | 1. From the meal plan list, edit or delete a plan. | The plan is updated or removed from the list. | E2E |
+
+### 4.5 Shopping List Generation
+
+| Test ID | Requirement(s) | Test Description | Test Steps | Expected Result | Test Type |
+|---|---|---|---|---|---|
+| **TC-SL-001** | FR-1.5.1, FR-1.5.3 | Verify that a shopping list can be generated. | 1. Navigate to a meal plan.<br>2. Click "Generate Shopping List". | A new page is displayed showing the shopping list. | E2E |
+| **TC-SL-002** | FR-1.5.2 | Verify consolidation logic for flexible units. | 1. Create a meal plan with recipes containing:<br> - 100g cheese<br> - 0.2kg cheese<br> - 1 apple<br> - 2 apples<br> - 1 can tomatoes<br> - 1 cup flour & 200g flour<br>2. Generate list. | The list should show:<br> - 300g cheese (or 0.3kg)<br> - 3 apples<br> - 1 can tomatoes<br> - 1 cup flour<br> - 200g flour (unconsolidated) | Integration |
+| **TC-SL-003** | FR-1.5.4 | Verify a user can manually edit a generated shopping list. | 1. Generate a shopping list.<br>2. Click "Edit List", add/remove an item, and save. | The changes are persisted and visible on the shopping list. | E2E |
+
+### 4.6 Future/Desired Features
+
+| Test ID | Requirement(s) | Test Description | Test Steps | Expected Result | Test Type |
+|---|---|---|---|---|---|
+| **TC-FF-001** | FR-1.7.2 | Verify PDF export. (When implemented) | 1. Generate a list.<br>2. Click "Export to PDF". | A PDF file is downloaded and its content is correct. | E2E |
+| **TC-FF-002** | FR-1.7.1 | Verify local recipe search. (When implemented) | 1. Search for a local recipe by name. | The list filters to show only matching recipes. | E2E |
+
+## 5. Non-Functional Testing
+
+| Test ID | Requirement(s) | Test Description | Test Type |
+|---|---|---|---|
+| **TC-NFR-001** | NFR-2.1.1, NFR-2.1.3 | Measure page load and API response times. | Performance |
+| **TC-NFR-002** | NFR-2.1.2 | Measure time for recipe search and extraction. | Performance |
+| **TC-NFR-003** | NFR-2.2.1, NFR-2.2.2 | Conduct exploratory testing for usability and feedback. | Manual (Usability) |
+| **TC-NFR-004** | NFR-2.3.2 | Test invalid inputs and error handling. | E2E |
+| **TC-NFR-005** | NFR-2.5.1 | Test the accuracy of the AI recipe extraction model. | Manual |

--- a/discussion.md
+++ b/discussion.md
@@ -1,0 +1,11 @@
+# Discussion & Clarifications
+
+This file contains questions from Jules, the AI software engineer, to clarify the task requirements.
+
+## Initial Questions
+
+1.  **Regarding the `.ai` directory:** You mentioned creating an `.ai` catalog. Should I create a directory named `.ai` at the root of the repository for the output files? Also, do you have a preferred naming convention for the files I'll be creating in this directory (e.g., `01_feature_summary.md`, `02_requirements.md`, etc.)?
+
+2.  **Regarding the end goal:** The overall task is to "stabilize the code." My current instructions focus on analysis and planning. Is the ultimate goal for me to later implement the tests from the test plan and fix any discovered issues, or is this task purely about generating these analysis documents?
+
+3.  **Regarding the feature summary:** When I summarize features from the `Readme.md` files, are you looking for a high-level bulleted list, or would you prefer a more detailed description for each feature? If there are multiple `Readme.md` files, should I treat the one in the root directory as the primary source?


### PR DESCRIPTION
This commit adds a new analysis documents, `.ai/` directory.

The documents describe planned features, tests and stack