### PR TITLE
Fix meal plan description handling in API

### DIFF
--- a/.ai/next_step.md
+++ b/.ai/next_step.md
@@ -1,19 +1,16 @@
-The development environment has been successfully repaired, and the Meal Plan Management UI is now testable.
+The Meal Plan Management UI has been tested, and a critical bug has been fixed.
 
-The following work was completed:
-- The frontend Vite server was fixed by resolving issues with Tailwind CSS and PostCSS configuration.
-- The backend Flask server was debugged and fixed to ensure all API routes are correctly registered and served.
-- The UI for the Meal Plan List was visually verified and is rendering correctly.
+**Work Completed:**
+- Thoroughly tested the API endpoints for the Meal Plan Management UI (Create, Read, Update, Delete).
+- Identified and fixed a bug where the `description` field for meal plans was not being created, updated, or returned correctly by the API.
+- The fix was implemented across the data model, CRUD layer, and API layer.
+- The fix has been verified, and all code quality checks (linting and formatting) are passing.
 
-**CRITICAL NEXT STEP: Test the Meal Plan Management UI**
+**CRITICAL NEXT STEP: Enhance API and Testing**
 
-The immediate priority is to thoroughly test the new Meal Plan Management UI to ensure it is fully functional and free of bugs.
+The immediate priority is to improve the robustness of the application by enhancing the API and adding automated tests.
 
 **Next Implementation Steps:**
-1.  **Thoroughly test the new Meal Plan Management UI.** This includes:
-    - Creating new meal plans.
-    - Editing existing meal plans.
-    - Viewing meal plan details.
-    - Deleting meal plans.
-2.  **Fix any bugs found during testing.**
-3.  **Consider adding end-to-end tests** for the new UI to prevent future regressions.
+1.  **Add End-to-End Tests:** Create end-to-end tests for the Meal Plan Management UI to automate the testing process and prevent future regressions. This was suggested in a previous `next_step.md`.
+2.  **Enhance Recipe API:** The recipe creation is currently only available via a traditional form submission. To improve the consistency of the API, a JSON API endpoint for creating recipes (`POST /api/recipes`) should be added.
+3.  **Continue UI Development:** Continue to build out the React UI to cover all features of the application, such as recipe creation and editing, which are currently only available through Jinja2 templates.

--- a/meal_planner_app/crud.py
+++ b/meal_planner_app/crud.py
@@ -125,12 +125,14 @@ def reset_meal_plans_db():
 
 
 def create_meal_plan(
-    name: str, recipe_ids: Optional[List[uuid.UUID]] = None
+    name: str,
+    description: str = "",
+    recipe_ids: Optional[List[uuid.UUID]] = None,
 ) -> MealPlan:
     """Creates a new meal plan."""
     if recipe_ids is None:
         recipe_ids = []
-    meal_plan = MealPlan(name=name, recipe_ids=recipe_ids)
+    meal_plan = MealPlan(name=name, description=description, recipe_ids=recipe_ids)
     meal_plans_db.append(meal_plan)
     return meal_plan
 
@@ -191,6 +193,7 @@ def delete_meal_plan(meal_plan_id: uuid.UUID) -> bool:
 def update_meal_plan(
     meal_plan_id: uuid.UUID,
     name: Optional[str] = None,
+    description: Optional[str] = None,
     recipe_ids: Optional[List[uuid.UUID]] = None,
 ) -> Optional[MealPlan]:
     """Updates an existing meal plan's name and/or recipe list."""
@@ -200,6 +203,9 @@ def update_meal_plan(
 
     if name is not None:
         meal_plan.name = name
+
+    if description is not None:
+        meal_plan.description = description
 
     if recipe_ids is not None:
         # Here we replace the entire list of recipe_ids

--- a/meal_planner_app/main.py
+++ b/meal_planner_app/main.py
@@ -369,6 +369,7 @@ def _meal_plan_to_dict(meal_plan: MealPlan) -> dict:
     return {
         "id": str(meal_plan.meal_plan_id),
         "name": meal_plan.name,
+        "description": meal_plan.description,
         "recipe_ids": [str(rid) for rid in meal_plan.recipe_ids],
     }
 
@@ -406,10 +407,13 @@ def api_create_meal_plan():
         abort(400, description="Name is required.")
 
     name = data["name"]
+    description = data.get("description", "")
     recipe_ids_str = data.get("recipe_ids", [])
     recipe_ids = [uuid.UUID(rid) for rid in recipe_ids_str]
 
-    created_meal_plan = crud.create_meal_plan(name, recipe_ids)
+    created_meal_plan = crud.create_meal_plan(
+        name, description=description, recipe_ids=recipe_ids
+    )
     return jsonify(_meal_plan_to_dict(created_meal_plan)), 201
 
 
@@ -430,6 +434,7 @@ def api_update_meal_plan(meal_plan_id: uuid.UUID):
         abort(400)
 
     name = data.get("name")
+    description = data.get("description")
     recipe_ids_str = data.get("recipe_ids")
     recipe_ids = (
         [uuid.UUID(rid) for rid in recipe_ids_str]
@@ -438,7 +443,7 @@ def api_update_meal_plan(meal_plan_id: uuid.UUID):
     )
 
     updated_meal_plan = crud.update_meal_plan(
-        meal_plan_id, name=name, recipe_ids=recipe_ids
+        meal_plan_id, name=name, description=description, recipe_ids=recipe_ids
     )
     if not updated_meal_plan:
         abort(404)

--- a/meal_planner_app/models/meal_plan.py
+++ b/meal_planner_app/models/meal_plan.py
@@ -12,6 +12,7 @@ class MealPlan:  # pylint: disable=too-few-public-methods
     def __init__(
         self,
         name: str,
+        description: str = "",
         recipe_ids: Optional[List[uuid.UUID]] = None,
         meal_plan_id: Optional[uuid.UUID] = None,
     ):
@@ -20,11 +21,13 @@ class MealPlan:  # pylint: disable=too-few-public-methods
 
         Args:
             name: The name of the meal plan (e.g., "Week 1 Dinners").
+            description: A short description of the meal plan.
             recipe_ids: A list of recipe UUIDs included in this plan. Defaults to an empty list.
             meal_plan_id: An optional UUID for the meal plan; one is generated if not provided.
         """
         self.meal_plan_id = meal_plan_id if meal_plan_id else uuid.uuid4()
         self.name = name
+        self.description = description
         self.recipe_ids = recipe_ids if recipe_ids is not None else []
 
     def __repr__(self):


### PR DESCRIPTION
The `description` field for meal plans was not being correctly handled by the API. It was missing from the `MealPlan` model, the CRUD functions, and the API endpoints.

This commit fixes the bug by:
- Adding the `description` attribute to the `MealPlan` model.
- Updating the `create_meal_plan` and `update_meal_plan` CRUD functions to handle the `description`.
- Updating the `api_create_meal_plan` and `api_update_meal_plan` API endpoints to process the `description` from the request.
- Updating the `_meal_plan_to_dict` serialization function to include the `description` in API responses.