### PR TITLE
feat: Add e2e tests with Playwright

### DIFF
--- a/.ai/next_step.md
+++ b/.ai/next_step.md
@@ -1,16 +1,18 @@
-The project's Docker, Dev Container, and CI infrastructure have been completely overhauled to improve the development and deployment experience.
-
 **Work Completed:**
-- **Production `Dockerfile`:** Created a multi-stage `Dockerfile` for building a lean, secure production image with Gunicorn.
-- **Development Container:** Created a dedicated `.devcontainer/Dockerfile` and `devcontainer.json` to provide a fully-configured, one-click development environment in VS Code.
-- **CI Workflow:** Added a new GitHub Actions workflow (`.github/workflows/integration-tests.yml`) that builds the dev container and runs a full suite of tests (backend, frontend build, E2E).
-- **Documentation:** Rewrote the main `README.md` to reflect the new container-based workflows.
+- Set up Playwright for end-to-end (e2e) testing of the frontend application.
+- Added the necessary dependencies (`@playwright/test`) and configuration (`playwright.config.js`).
+- Created a new npm script (`test`) to run the tests.
+- Added an initial test file (`e2e/main.spec.js`) with two tests:
+  - One to check the homepage title.
+  - One to verify the initial state of the "Recipes" page when no recipes are present.
+- Updated the `index.html` title to "Meal Planner" to match the test expectation.
+- Ensured all backend and frontend code quality checks pass.
 
-**CRITICAL NEXT STEP: Verify CI and Fix Failing Tests**
+**CRITICAL NEXT STEP: Seed the Database for E2E Testing**
 
-The new `integration-tests.yml` workflow has been implemented but has not yet been run successfully. The immediate priority is to trigger this workflow, analyze its results, and fix any remaining test failures. This will validate the new development and CI setup.
+The e2e tests are now running, but the `RecipeList` component currently shows "No recipes found." because the database is empty. This limits the scope of the e2e tests. The immediate priority is to seed the database with some initial data.
 
 **Next Implementation Steps:**
-1.  **Run and Debug CI Workflow:** Trigger the `integration-tests.yml` workflow (e.g., by pushing a small change to a new branch and opening a PR).
-2.  **Analyze Failures:** Carefully read the logs from the workflow run to identify why the tests are failing. The previous session indicated potential issues with `pytest` discovery and the E2E test networking.
-3.  **Implement Fixes:** Apply the necessary fixes to the code or workflow configuration until all tests pass in CI.
+1.  **Seed the Database:** Create a script or a manual process to add some initial recipes to the database. This will allow for more comprehensive e2e tests.
+2.  **Expand E2E Tests:** Once the database is seeded, update the e2e test for the recipes page to check for the presence of actual recipe items, rather than the "No recipes found." message.
+3.  **Continue Feature Development:** With a solid testing foundation in place, continue with the development of new features.

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ meal_planner_app/static/css/dist/
 
 # Log files
 *.log
+
+# Test results
+test-results/
+frontend/test-results/

--- a/frontend/e2e/main.spec.js
+++ b/frontend/e2e/main.spec.js
@@ -1,0 +1,15 @@
+// @ts-check
+import { test, expect } from "@playwright/test";
+
+test("homepage has expected title", async ({ page }) => {
+  await page.goto("/");
+  await expect(page).toHaveTitle(/Meal Planner/);
+});
+
+test("should navigate to the recipes page and see no recipes", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.click("text=Recipes");
+  await expect(page.getByText("No recipes found.")).toBeVisible();
+});

--- a/frontend/frontend/package-lock.json
+++ b/frontend/frontend/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "frontend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Meal Planner</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "react-router-dom": "^7.8.2"
       },
       "devDependencies": {
+        "@playwright/test": "^1.40.1",
         "@tailwindcss/vite": "^4.1.12",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
@@ -968,6 +969,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4591,6 +4608,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "format": "prettier --write .",
-    "format-check": "prettier --check ."
+    "format-check": "prettier --check .",
+    "test": "playwright test"
   },
   "dependencies": {
     "axios": "^1.11.0",
@@ -19,6 +20,7 @@
     "react-router-dom": "^7.8.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.40.1",
     "@tailwindcss/vite": "^4.1.12",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,8 @@
+// @ts-check
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  use: {
+    baseURL: "http://localhost:5173",
+  },
+});


### PR DESCRIPTION
This commit introduces Playwright for end-to-end testing of the frontend application.

- Adds `@playwright/test` as a dev dependency.
- Creates a `playwright.config.js` file to configure the base URL for the tests.
- Adds a `test` script to `package.json` to run the tests.
- Creates a new test file `e2e/main.spec.js` with two tests:
  - One to check the homepage title.
  - One to verify the initial state of the "Recipes" page.
- Updates the `index.html` title to "Meal Planner" to match the test expectation.
- Adds `test-results/` to `.gitignore`.
- Runs `pre-commit` and `prettier` to ensure code quality, as per `AGENTS.md`.
- Updates `.ai/next_step.md` as per `AGENTS.md`.