### PR TITLE
fix(devcontainer): Fix build for e2e tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,5 +25,5 @@
     "eamodio.gitlens"
   ],
   "forwardPorts": [5000, 5173],
-  "postCreateCommand": "pip install -e .[dev] && (cd frontend && npm install)"
+  "postCreateCommand": "pip install -e .[dev] && cd frontend && npm install && npm run build"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dev = [
     "pytest",
     "black",
     "pre-commit",
+    "gunicorn",
 ]
 
 [build-system]


### PR DESCRIPTION
The dev container was failing to install all necessary dependencies for the frontend, causing the e2e tests to fail.

This change modifies the dev container setup to ensure all dependencies are installed and the frontend assets are built.

- Adds `gunicorn` as a development dependency to `pyproject.toml`.
- Updates the `postCreateCommand` in `.devcontainer/devcontainer.json` to install all python and node dependencies, and to run `npm run build` for the frontend.
- The original `.devcontainer/Dockerfile` is restored, as the setup is now handled by the `postCreateCommand`.