### PR TITLE
fix(ci): Configure Dockerfile for e2e tests

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,8 +16,16 @@ RUN apt-get update && apt-get install -y curl gnupg && \
 # Copy the application files
 COPY . /app/
 
-# The postCreateCommand in devcontainer.json will handle dependency installation.
-# This keeps the image build faster and dependencies can be updated without rebuilding the image.
+# Install Python dependencies
+RUN pip install .[dev]
 
-# Set the default command to keep the container running
+# Install frontend dependencies and build assets
+WORKDIR /app/frontend
+RUN npm install
+RUN npm run build
+
+# Reset WORKDIR for any subsequent commands
+WORKDIR /app
+
+# Set a default command to keep the container running if used interactively
 CMD ["sleep", "infinity"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dev = [
     "pytest",
     "black",
     "pre-commit",
+    "gunicorn",
 ]
 
 [build-system]


### PR DESCRIPTION
The CI environment was failing to run e2e tests because the Docker image was missing necessary dependencies and build steps.

This change modifies the test environment setup to ensure all dependencies are installed and the frontend assets are built correctly within the Docker image defined by .devcontainer/Dockerfile.

- Adds `gunicorn` as a development dependency to `pyproject.toml`.
- Modifies `.devcontainer/Dockerfile` to install all Python and Node.js dependencies and to run the frontend build.