### PR TITLE
fix(react): correct MealPlan React components to use backend recipe_ids API contract

### DIFF
--- a/.ai/next_step.md
+++ b/.ai/next_step.md
@@ -1,3 +1,16 @@
+**PR Babysit Status (rkurc/meal-planner#25) - Re-resolve Conflicts (new cycle after main #28 merge):**
+- Fresh query: state=OPEN, mergeable=CONFLICTING, mergeStateStatus=DIRTY (despite prior SUCCESS checks), reviewDecision="", statusCheckRollup=[all SUCCESS from before: backend, frontend, test-in-container].
+- git fetch origin; git checkout -B pr/fix-meal-plan-react-api-contract origin/pr/fix-meal-plan-react-api-contract; git rebase origin/main.
+- Conflicts in 2 files: frontend/e2e/main.spec.js (whitespace/format in test expects) and .ai/next_step.md (babysit history between #28 on main vs #25 docs/fix commits).
+- Used git ls-files/git status to identify; read FULL files with read_file tool (full content + markers).
+- Resolved by taking HEAD (main) versions for both (current E2E formatting + latest babysit history from #28); removed markers; git add; rebase --continue succeeded (replayed the meal-plan contract fix commits on top of current main).
+- Per AGENTS.md: read .ai/next_step.md at start; all future verify with Docker meal-planner-dev (black/pylint/pytest/prettier/lint/build); update this .ai before commit/push.
+- MANDATORY review threads (exact mktemp + NO_COLOR=1 gh api graphql + pagination + filter isResolved=false): totalCount=0, unresolved=0 (confirmed again).
+- fix_count_delta=0 this cycle (resolution via git; .ai update for handover will be committed).
+- Will verify gates, push --force-with-lease, post comment "Automated fix: resolved merge conflicts and rebased."
+- Timestamp: 2026-06-17 (resume cycle)
+- last_status will be healthy after.
+
 **PR Babysit Status (rkurc/meal-planner#28) - Conflict Resolution (standalone pr/code-quality-gates):**
 - Fresh query: state=OPEN, mergeable=CONFLICTING, mergeStateStatus=DIRTY, reviewDecision="", statusCheckRollup=[], headRefName=pr/code-quality-gates, baseRefName=main.
 - git fetch origin; git checkout -B pr/code-quality-gates origin/pr/code-quality-gates; git rebase origin/main.

--- a/frontend/src/components/MealPlanDetail.jsx
+++ b/frontend/src/components/MealPlanDetail.jsx
@@ -9,6 +9,7 @@ const MealPlanDetail = () => {
   const [mealPlan, setMealPlan] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [recipesInPlan, setRecipesInPlan] = useState([]);
 
   useEffect(() => {
     axios
@@ -22,6 +23,24 @@ const MealPlanDetail = () => {
         setLoading(false);
       });
   }, [id]);
+
+  useEffect(() => {
+    if (!mealPlan || !mealPlan.recipe_ids || mealPlan.recipe_ids.length === 0) {
+      setRecipesInPlan([]);
+      return;
+    }
+    // Fetch all recipes then filter (small dataset; keeps one request)
+    axios
+      .get("/api/recipes")
+      .then((res) => {
+        const byId = Object.fromEntries(res.data.map((r) => [r.id, r]));
+        const resolved = mealPlan.recipe_ids
+          .map((rid) => byId[rid])
+          .filter(Boolean);
+        setRecipesInPlan(resolved);
+      })
+      .catch(() => setRecipesInPlan([]));
+  }, [mealPlan]);
 
   const handleDelete = () => {
     if (window.confirm("Are you sure you want to delete this meal plan?")) {
@@ -61,9 +80,9 @@ const MealPlanDetail = () => {
         <p className="text-gray-600 mb-6">{mealPlan.description}</p>
 
         <h3 className="text-2xl font-semibold text-gray-700 mb-4">Recipes</h3>
-        {mealPlan.recipes && mealPlan.recipes.length > 0 ? (
+        {recipesInPlan.length > 0 ? (
           <ul className="space-y-2">
-            {mealPlan.recipes.map((recipe) => (
+            {recipesInPlan.map((recipe) => (
               <li key={recipe.id} className="bg-gray-100 p-3 rounded-md">
                 <span className="font-medium">{recipe.name}</span>
               </li>

--- a/frontend/src/components/MealPlanForm.jsx
+++ b/frontend/src/components/MealPlanForm.jsx
@@ -16,17 +16,20 @@ const MealPlanForm = () => {
 
   useEffect(() => {
     const fetchRecipes = axios.get("/api/recipes");
-    const fetchMealPlan = id ? axios.get(`/api/meal-plans/${id}`) : null;
+    const fetches = [fetchRecipes];
+    if (id) {
+      fetches.push(axios.get(`/api/meal-plans/${id}`));
+    }
 
-    Promise.all([fetchRecipes, fetchMealPlan])
+    Promise.all(fetches)
       .then(([recipesResponse, mealPlanResponse]) => {
         setAllRecipes(recipesResponse.data);
         if (mealPlanResponse) {
-          const { name, description, recipes } = mealPlanResponse.data;
+          const data = mealPlanResponse.data;
           setFormData({
-            name,
-            description,
-            recipe_ids: recipes.map((r) => r.id),
+            name: data.name || "",
+            description: data.description || "",
+            recipe_ids: Array.isArray(data.recipe_ids) ? data.recipe_ids : [],
           });
         }
         setLoading(false);
@@ -44,7 +47,7 @@ const MealPlanForm = () => {
 
   const handleRecipeChange = (e) => {
     const { value, checked } = e.target;
-    const recipeId = parseInt(value, 10);
+    const recipeId = value; // keep as string UUID from API
     setFormData((prev) => {
       const newRecipeIds = checked
         ? [...prev.recipe_ids, recipeId]


### PR DESCRIPTION
## Summary
Fixes the React <-> backend API contract mismatch for meal plans:
- `MealPlanForm`: robust load for create (no null in Promise.all) + edit; use `recipe_ids: string[]` directly (UUIDs, no `parseInt`); checkboxes now match correctly.
- `MealPlanDetail`: after fetch, resolve recipe names/details by fetching `/api/recipes` and matching on `recipe_ids` (backend only ever serializes `recipe_ids`, never a `recipes` array of objects).

## Changes
- frontend/src/components/MealPlanForm.jsx
- frontend/src/components/MealPlanDetail.jsx
- .ai/next_step.md (handoff)

## Verification (ALL via Docker dev image)
- `docker build -f .devcontainer/Dockerfile -t meal-planner-dev .`
- pytest: 65 passed
- Frontend: npm run build succeeded; prettier format-check passed (via Docker)
- Python: black + pylint clean
- pre-commit checks equivalent passed
- No backend changes (contract was already correct)

Leaves full E2E (with data seeding) + reliability to follow-on as planned.

Branch: pr/fix-meal-plan-react-api-contract