### PR TITLE
feat: add unit suggestions via /api/units (Task 2)

### DIFF
--- a/.ai/next_step.md
+++ b/.ai/next_step.md
@@ -410,3 +410,61 @@ This keeps the PDF feature robust while aligning with long-term i18n goals.
 **Next:** This is ready to push along with prior PDF/Unicode/pylint fixes. Rebuild dev image if testing locally; E2E can cover later.
 
 **Verification checklist update:** Frontend Docker checks passed cleanly for this change.
+
+---
+
+## Task 2 (isolated): Unit suggestions via /api/units (new recipe, edit recipe, shopping list edit) (2026-07-12)
+
+**Isolated task completed on branch `feat/add-unit-suggestions` (created per standing instruction before any edits).**
+
+**What was implemented (strictly unit-suggestion related code only):**
+
+- Backend:
+  - `meal_planner_app/crud.py`: Added `list_unique_units()` collecting unique non-empty `unit` strings from all `recipe.ingredients` (modeled exactly on `list_unique_ingredient_names` / `list_unique_locations`).
+  - `meal_planner_app/main.py`: Added `GET /api/units` endpoint (after `/api/locations`), returns sorted list via `crud.list_unique_units()` (with pylint disable, matching siblings).
+- Frontend (non-blocking fetch pattern exactly as knownIngredients/knownLocations):
+  - `frontend/src/components/RecipeForm.jsx` (new + edit recipe): added `knownUnits` state; third fetch("/api/units") in the useEffect (empty deps, non-fatal catch); `list="known-units"` on unit `<input>` in ingredient rows; `<datalist id="known-units">` after locations datalist.
+  - `frontend/src/components/ShoppingListView.jsx` (shopping list edit, used from meal plan): added `knownUnits` state + matching fetch in the suggestions useEffect; `list="known-units"` on unit input in edit rows; `<datalist id="known-units">`.
+- Datalists preserve free-text entry (standard HTML behavior).
+- No changes to meal plan recipe selection (task 4), no master unit storage, no other files.
+- Added test: `test_api_get_units` in `meal_planner_app/tests/test_shopping_list_api.py` (controls data, asserts sorted uniques, excludes empty, no dups; +1 test).
+
+**Files changed (only):**
+- meal_planner_app/crud.py
+- meal_planner_app/main.py
+- frontend/src/components/RecipeForm.jsx
+- frontend/src/components/ShoppingListView.jsx
+- meal_planner_app/tests/test_shopping_list_api.py
+- .ai/next_step.md (this update)
+
+**Verification evidence (ALL via Docker, no host python/node/npm/black/pylint/pytest; per AGENTS.md):**
+
+- Branch: `git checkout -b feat/add-unit-suggestions` (before edits).
+- Restored lock only for env (git checkout -- ... ; no package change).
+- `docker buildx bake dev` → succeeded with "exporting to image ... DONE", "naming to docker.io/library/meal-planner:dev done".
+- Backend tests: `docker run --rm -v "$(pwd):/app" -w /app meal-planner:dev python -m pytest meal_planner_app/tests/ -q --tb=short` → **72 passed** ( +1 ; units test included).
+- Black: `docker run --rm -v "$(pwd):/app" -w /app meal-planner:dev python -m black --check .` → "All done! 15 files would be left unchanged."
+- Pylint: `docker run --rm -v "$(pwd):/app" -w /app meal-planner:dev python -m pylint --rcfile=.pylintrc meal_planner_app/` → "Your code has been rated at 10.00/10".
+- Frontend via node:20-alpine (with npm ci):
+  - `docker run --rm -v "$(pwd)/frontend:/app" -w /app node:20-alpine sh -c 'npm ci --no-audit --no-fund --silent && npm run format-check'` → "All matched files use Prettier code style!"
+  - `docker run --rm -v "$(pwd)/frontend:/app" -w /app node:20-alpine sh -c 'npm ci --no-audit --no-fund --silent && npm run lint'` → (clean, no errors).
+- Also via meal-planner:dev: `docker run --rm -v "$(pwd)/frontend:/app/frontend" -w /app/frontend meal-planner:dev sh -c 'npm run format-check && npm run lint'` → clean Prettier + eslint.
+- (Pre-commit attempted but env git limitation inside container; core black/pylint + format/lint covered per past .ai handling.)
+
+**Status:** Task 2 done. Suggestions now available for units in recipe forms + shopping list edit (from meal plans), consistent with ingredients/locations. Free text still works.
+
+**Next steps (for handoff):**
+- Commit + push branch (include this .ai update).
+- Report last commit SHA.
+- E2E (if needed) can later assert datalist presence, but out of scope here.
+- Do not merge overlapping tasks; isolated to units.
+- Update any future handoff in .ai/next_step.md .
+
+**Definition of done (self-check):**
+- [x] list_unique_units + /api/units implemented + tested
+- [x] RecipeForm + ShoppingListView use datalists for units
+- [x] non-blocking fetch, no free-text breakage
+- [x] Only unit suggestion code touched
+- [x] All verification Docker commands executed + evidence captured
+- [x] .ai/next_step.md updated + will commit together
+

--- a/frontend/src/components/RecipeForm.jsx
+++ b/frontend/src/components/RecipeForm.jsx
@@ -18,6 +18,7 @@ const RecipeForm = () => {
   const [error, setError] = useState(null);
   const [knownIngredients, setKnownIngredients] = useState([]);
   const [knownLocations, setKnownLocations] = useState([]);
+  const [knownUnits, setKnownUnits] = useState([]);
 
   useEffect(() => {
     if (isEditing) {
@@ -75,6 +76,20 @@ const RecipeForm = () => {
       .then((data) => {
         if (Array.isArray(data)) {
           setKnownLocations(data);
+        }
+      })
+      .catch(() => {
+        // non-fatal
+      });
+
+    fetch("/api/units")
+      .then((response) => {
+        if (!response.ok) return [];
+        return response.json();
+      })
+      .then((data) => {
+        if (Array.isArray(data)) {
+          setKnownUnits(data);
         }
       })
       .catch(() => {
@@ -288,6 +303,7 @@ const RecipeForm = () => {
                   onChange={(e) =>
                     handleIngredientChange(index, "unit", e.target.value)
                   }
+                  list="known-units"
                   className="w-24 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                 />
                 <input
@@ -326,6 +342,11 @@ const RecipeForm = () => {
             <datalist id="known-locations">
               {knownLocations.map((loc, i) => (
                 <option key={i} value={loc} />
+              ))}
+            </datalist>
+            <datalist id="known-units">
+              {knownUnits.map((unit, i) => (
+                <option key={i} value={unit} />
               ))}
             </datalist>
           </div>

--- a/frontend/src/components/ShoppingListView.jsx
+++ b/frontend/src/components/ShoppingListView.jsx
@@ -10,6 +10,7 @@ const ShoppingListView = ({ mealPlanId, mealPlanName }) => {
 
   const [knownIngredients, setKnownIngredients] = useState([]);
   const [knownLocations, setKnownLocations] = useState([]);
+  const [knownUnits, setKnownUnits] = useState([]);
 
   useEffect(() => {
     // Try to fetch existing shopping lists for this meal plan
@@ -53,6 +54,20 @@ const ShoppingListView = ({ mealPlanId, mealPlanName }) => {
       .then((data) => {
         if (Array.isArray(data)) {
           setKnownLocations(data);
+        }
+      })
+      .catch(() => {
+        // non-fatal
+      });
+
+    fetch("/api/units")
+      .then((response) => {
+        if (!response.ok) return [];
+        return response.json();
+      })
+      .then((data) => {
+        if (Array.isArray(data)) {
+          setKnownUnits(data);
         }
       })
       .catch(() => {
@@ -243,6 +258,7 @@ const ShoppingListView = ({ mealPlanId, mealPlanName }) => {
                   onChange={(e) =>
                     handleItemChange(index, "unit", e.target.value)
                   }
+                  list="known-units"
                   className="w-20 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                 />
                 <input
@@ -279,6 +295,11 @@ const ShoppingListView = ({ mealPlanId, mealPlanName }) => {
           <datalist id="known-locations">
             {knownLocations.map((loc, i) => (
               <option key={i} value={loc} />
+            ))}
+          </datalist>
+          <datalist id="known-units">
+            {knownUnits.map((unit, i) => (
+              <option key={i} value={unit} />
             ))}
           </datalist>
         </div>

--- a/meal_planner_app/crud.py
+++ b/meal_planner_app/crud.py
@@ -132,6 +132,16 @@ def list_unique_locations() -> List[str]:
     return sorted(locs)
 
 
+def list_unique_units() -> List[str]:
+    """Returns a sorted list of unique non-empty unit strings from all recipe ingredients."""
+    units: set = set()
+    for recipe in recipes_db:
+        for ing in recipe.ingredients:
+            if ing.unit and str(ing.unit).strip():
+                units.add(str(ing.unit).strip())
+    return sorted(units)
+
+
 def reset_recipes_db():
     """Helper function to reset the database, primarily for testing."""
     # pylint: disable=global-statement

--- a/meal_planner_app/main.py
+++ b/meal_planner_app/main.py
@@ -466,6 +466,13 @@ def api_get_locations():
     return jsonify(locs)
 
 
+@app.route("/api/units", methods=["GET"])
+def api_get_units():
+    """API endpoint to get unique units for suggestions (collected from recipe ingredients)."""
+    units = crud.list_unique_units()  # pylint: disable=no-member
+    return jsonify(units)
+
+
 @app.route("/api/recipes", methods=["POST"])
 def api_create_recipe():
     """API endpoint to create a new recipe."""

--- a/meal_planner_app/tests/test_shopping_list_api.py
+++ b/meal_planner_app/tests/test_shopping_list_api.py
@@ -256,6 +256,34 @@ class ShoppingListApiTestCase(unittest.TestCase):
         self.assertIn("Dairy", locs)
         self.assertIn("Bakery", locs)
 
+    def test_api_get_units(self):
+        """GET /api/units returns sorted unique non-empty unit strings from recipes."""
+        # Reset and seed controlled data with mix of units (incl. empty)
+        crud.reset_recipes_db()
+        crud.reset_meal_plans_db()
+        crud.create_recipe(
+            name="Test Units Recipe",
+            instructions="Test.",
+            ingredients_data=[
+                {"name": "Milk", "quantity": 1, "unit": "l"},
+                {"name": "Flour", "quantity": 2, "unit": "cups"},
+                {"name": "Salt", "quantity": 1, "unit": "pinch"},
+                {"name": "Egg", "quantity": 1, "unit": ""},  # should be excluded
+                {"name": "Sugar", "quantity": 1, "unit": "cups"},  # duplicate
+            ],
+        )
+        resp = self.client.get("/api/units")
+        self.assertEqual(resp.status_code, 200)
+        units = resp.get_json()
+        self.assertIsInstance(units, list)
+        self.assertEqual(units, sorted(units))
+        self.assertIn("l", units)
+        self.assertIn("cups", units)
+        self.assertIn("pinch", units)
+        self.assertNotIn("", units)
+        # Duplicates removed
+        self.assertEqual(units.count("cups"), 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Backend: list_unique_units() in crud.py (unique non-empty from recipe ings); GET /api/units in main.py.

Frontend: knownUnits + datalist (list="known-units") in RecipeForm.jsx (new/edit) and ShoppingListView.jsx (SL edit); non-blocking fetch matching ingredients/locations pattern. Free-text preserved.

Test: test_api_get_units added.

Strictly followed scope (no mealplan recipe UI, no master units data).

All via Docker per AGENTS: bake dev, pytest (72 passed), black clean, pylint 10/10, node:20-alpine + meal-planner:dev for npm ci+format+lint.

Updated .ai/next_step.md with evidence.